### PR TITLE
Add initial support for non-final fields

### DIFF
--- a/codebases/non_final_fields/next/src/Fields.java
+++ b/codebases/non_final_fields/next/src/Fields.java
@@ -1,0 +1,8 @@
+public class Fields {
+    static int A = 1;
+    static int B = 2;
+
+    static {
+        A = 3;
+    }
+}

--- a/codebases/non_final_fields/next/src/Simple.java
+++ b/codebases/non_final_fields/next/src/Simple.java
@@ -1,0 +1,11 @@
+import utils.*;
+
+public class Simple {
+
+    static int SOME_CONSTANT = 5;
+
+    @Test(shouldRunSymbolic = false, shouldRunDynamic = true)
+    public void simpleTest() {
+        assert SOME_CONSTANT == Fields.A + Fields.B;
+    }
+}

--- a/codebases/non_final_fields/previous/src/Fields.java
+++ b/codebases/non_final_fields/previous/src/Fields.java
@@ -1,0 +1,8 @@
+public class Fields {
+    static int A = 1;
+    static int B = 2;
+
+    static {
+        A = 3;
+    }
+}

--- a/codebases/non_final_fields/previous/src/Simple.java
+++ b/codebases/non_final_fields/previous/src/Simple.java
@@ -1,0 +1,11 @@
+import utils.*;
+
+public class Simple {
+
+    static int SOME_CONSTANT = 5;
+
+    @Test(shouldRunSymbolic = false, shouldRunDynamic = true)
+    public void simpleTest() {
+        assert SOME_CONSTANT == Fields.A + Fields.B;
+    }
+}

--- a/src/diff_codebase.py
+++ b/src/diff_codebase.py
@@ -50,12 +50,9 @@ def method_snapshot(snapshot: EntitySnapshot, class_name: str, curr_method: obje
     # md5 is used as a cheap hash function
     snapshot.method_hashes[method_name] = hashlib.md5(hash_str.encode()).hexdigest()
 
-def field_snapshot(snapshot: EntitySnapshot, class_name: str, field: object):
-    # ignore fields with synthetic in access (compiler-created fields)
-    if "synthetic" not in field["access"]:
-        field_name = constant_name(field["name"], class_name)
-        field_value = int(field["value"]["value"]) if field["value"] else None #TODO: cast value to int
-        snapshot.constants[field_name] = field_value
+def field_snapshot(snapshot: EntitySnapshot, class_name: str, field_name: str, value: object):
+    name = constant_name(field_name, class_name)
+    snapshot.constants[name] = value
 
 # Assumes all tests are annotated with @Test
 def codebase_snapshot(codebase: Codebase) -> EntitySnapshot:
@@ -63,8 +60,8 @@ def codebase_snapshot(codebase: Codebase) -> EntitySnapshot:
     snapshot = EntitySnapshot()
 
     for class_name, fields in codebase.get_fields().items():
-        for field in fields:
-            field_snapshot(snapshot, class_name, field)
+        for field_name, field_value in fields.items():
+            field_snapshot(snapshot, class_name, field_name, field_value)
 
     for class_name, tests in codebase.get_tests().items():
         for test in tests:

--- a/src/diff_codebase.py
+++ b/src/diff_codebase.py
@@ -54,7 +54,8 @@ def field_snapshot(snapshot: EntitySnapshot, class_name: str, field: object):
     # ignore fields with synthetic in access (compiler-created fields)
     if "synthetic" not in field["access"]:
         field_name = constant_name(field["name"], class_name)
-        snapshot.constants[field_name] = int(field["value"]["value"]) #TODO: cast value to int
+        field_value = int(field["value"]["value"]) if field["value"] else None #TODO: cast value to int
+        snapshot.constants[field_name] = field_value
 
 # Assumes all tests are annotated with @Test
 def codebase_snapshot(codebase: Codebase) -> EntitySnapshot:
@@ -75,11 +76,11 @@ def diff_snapshots(prev: EntitySnapshot, next: EntitySnapshot) -> SnapshotDiff:
     diff = SnapshotDiff()
 
     for name, value in prev.method_hashes.items():
-        if next.method_hashes[name] != value: 
+        if name not in next.method_hashes or next.method_hashes[name] != value: 
             diff.changed_methods.add(name)
 
     for name, value in prev.constants.items():
-        if next.constants[name] != value: 
+        if name not in next.constants or next.constants[name] != value: 
             diff.changed_constants.add(name)
 
     return diff

--- a/src/main.py
+++ b/src/main.py
@@ -43,8 +43,8 @@ def run_tests(saved_result: SavedResult, required_tests: set[str], codebase : Co
                 continue
 
             stack = deque([Method(class_name, test["name"], test["code"]["bytecode"], [], deque(), 0)])
-            # result = SimpleInterpreter(codebase, stack).interpret()
-            result = SymbolicInterpreter(codebase, stack).interpret()
+            result = SimpleInterpreter(codebase, stack).interpret()
+            # result = SymbolicInterpreter(codebase, stack).interpret()
             
             saved_result.tests[full_test_name] = result
             for dependency in result.depends_on_methods:

--- a/src/simple_interpreter.py
+++ b/src/simple_interpreter.py
@@ -27,6 +27,8 @@ class Method:
 @dataclass
 class SimpleInterpreter:
     codebase: Codebase
+    # classname -> fieldname -> value
+    fields: dict[str, dict[str, object]]
     method_stack: deque[Method]
     done: Optional[str] = None
     step_count: int = 0
@@ -42,12 +44,27 @@ class SimpleInterpreter:
         self.constant_dependencies = set()
         self.method_dependencies = set([abs_method_name(m.class_name, m.name) for m in method_stack])
         self.linear_constraint_stack = []
+        self.fields = {}
+        # Initialize fields
+        for class_name, fields in codebase.get_fields().items():
+            self.fields[class_name] = {}
+            for field in fields:
+                # self.fields[class_name][field["name"]] = field.setdefault("value", {}).get("value", None)
+                self.fields[class_name][field["name"]] = field["value"]["value"] if field["value"] else None
+        # Prepend <clinit> for all classes to the method stack
+        for class_name in codebase.get_class_names():
+            if "<clinit>" not in codebase.get_class_methods(class_name):
+                continue
+            clinit_bytecode = codebase.get_method(class_name, "<clinit>", [])["code"]["bytecode"]
+            self.method_stack.append(Method(class_name, "<clinit>", clinit_bytecode, [], [], 0))
+
 
     def current_method(self) -> Method: 
         return self.method_stack[-1]
 
     def debug_step(self, next):
         l.debug(f"STEP {self.step_count}:")
+        l.debug(f"  METHOD: {self.current_method().class_name}.{self.current_method().name}")
         l.debug(f"  PC: {self.current_method().pc} {next}")
         l.debug(f"  LOCALS: {self.current_method().locals}")
         l.debug(f"  STACK: {self.current_method().stack}")
@@ -93,13 +110,21 @@ class SimpleInterpreter:
             self._next_cache_ID
         )
     
-    # Using recommended hack of just setting false when getting '$assertionsDisabled'.
-    # The rest of the operation is not used, so not implemented.
     def step_get(self, bc):
-        if bc["field"]["name"] == CONST_ASSERTION_DISABLED:
-            self.current_method().stack.append(0)
-        else:
-            self.done = f"can't handle get operations"
+        # Getting a static field from another class inside <clinit> is not allowed
+        if self.current_method().name == "<clinit>" and bc["field"]["class"] != self.current_method().class_name:
+            self.done = "field initialization must not reference other classes"
+            return
+        if not bc["static"]:
+            self.done = "non-static fields not implemented"
+            return
+        self.current_method().stack.append(self.fields[bc["field"]["class"]][bc["field"]["name"]])
+
+    def step_put(self, bc):
+        if not bc["static"]:
+            self.done = "non-static fields not implemented"
+            return
+        self.fields[bc["field"]["class"]][bc["field"]["name"]] = self.current_method().stack.pop()
 
     # Missing 'is' and 'notis' conditions (probably meant for isnull and isnonnull, but unclear)
     def __if(self, bc, inst_name, value1, value2):
@@ -136,7 +161,11 @@ class SimpleInterpreter:
     # Only handles static methods properly
     def step_invoke(self, bc):
         access = bc["access"]
-        if access == "special":
+        if bc["method"]["ref"]["name"] == "java/lang/Class" and bc["method"]["name"] == "desiredAssertionStatus":
+            # We always want assertions to be enabled
+            self.current_method().stack.pop()
+            self.current_method().stack.append(1)
+        elif access == "special":
             object_ref = self.current_method().stack.pop()
         elif access == "static":
             next_method_class = bc["method"]["ref"]["name"]

--- a/tests/test_non_final_fields.py
+++ b/tests/test_non_final_fields.py
@@ -1,0 +1,14 @@
+from common.codebase import *
+from simple_interpreter import Method, SimpleInterpreter
+
+def test_codebase_loads_fields():
+    codebase = load_codebase("non_final_fields", True)
+    assert codebase.get_fields()["Fields"]["A"] == 3
+
+def test_interpreter():
+    codebase = load_codebase("non_final_fields", True)
+    interpreter = SimpleInterpreter(codebase, deque([Method("Simple", "simpleTest", codebase.get_method(
+        "Simple", "simpleTest", [])["code"]["bytecode"], [], deque(), 0)]))
+    result = interpreter.interpret()
+    assert result.status == "ok"
+


### PR DESCRIPTION
TODO:
- [X] Move the clinits to the init function of the codebase and save the value of the fields there
- [X] Inside the interpreters init function, copy the fields from the codebase to the instance

This comes with the assumption that <clinit> only initializes static fields and has no other side effects.